### PR TITLE
Sqlite patch

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="../../../tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+        >
+    <testsuites>
+        <testsuite name="Roles Plugin Unit Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,0 +1,22 @@
+<?php
+namespace ShahiemSeymor\Roles\Tests;
+
+use PluginTestCase;
+
+class ExampleTest extends PluginTestCase
+{
+    /**
+     * Example test for loading database in memory (sqlite)
+     *
+     * The parent class PluginTestCase is included in OctoberCMS^ and will be available when the plugin is installed
+     * in the plugins directory of October. The base class calls a createApplication method that builds up the database
+     * in memory using the sqlite driver. If this test passes in the October context, then the database was built
+     * successfully.
+     *
+     * ^You must have updated OctoberCMS to the point that the PluginTestCase is in the /tests directory and that the
+     * composer.json loads it in autoload-dev.
+     */
+    public function test_loading_database_in_memory(){
+        $this->assertTrue(true);
+    }
+}

--- a/updates/add_dates.php
+++ b/updates/add_dates.php
@@ -10,7 +10,7 @@ class CreateDates extends Migration
     {
         Schema::table('shahiemseymor_assigned_roles', function($table)
         {
-            $table->timestamps();
+            $table->nullableTimestamps();
         });
     }
 

--- a/updates/add_default_and_description.php
+++ b/updates/add_default_and_description.php
@@ -10,8 +10,8 @@ class CreateDefaultAndDescription extends Migration
     {
         Schema::table('shahiemseymor_roles', function($table)
         {
-            $table->text('description');
-            $table->integer('default_group');
+            $table->text('description')->nullable();
+            $table->integer('default_group')->nullable();
         });
     }
 

--- a/updates/create_table.php
+++ b/updates/create_table.php
@@ -39,7 +39,7 @@ class CreateTable extends Migration
 
         Schema::table('users', function($table)
         {
-            $table->integer('primary_usergroup');
+            $table->integer('primary_usergroup')->default(0);
         });
     }
 


### PR DESCRIPTION
Fix for issue #5 .
# Issue

Cannot build tables when using the sqlite driver. Nullable/defaults must be declared.
# Fix

Declare nullable/default.
Add test case to verify functionality (must be executed within October framework)
# Notes

For users who already have this plugin installed, they must migrate it down and then back up to be functional. This can be done with php artisan plugin:refresh.
